### PR TITLE
opsgenie support for adding details to alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,17 @@ prefix: `consul-alerts/config/notifiers/opsgenie/`
 | enabled      | Enable the OpsGenie notifier. [Default: false]      |
 | cluster-name | The name of the cluster. [Default: "Consul Alerts"] |
 | api-key      | API Key                              (mandatory)    |
+| api-url      | Opsgenie api endpoint (default: us endpoint)        |
+| details      | key value map to add to each alert [Default: {}]    |
+
+The value of 'details' must be a json map of type string.
+```
+{
+  "environment": "production",
+  "platform":    "dc1"
+}
+```
+
 
 #### Amazon Web Services Simple Notification Service ("SNS")
 

--- a/consul/client.go
+++ b/consul/client.go
@@ -222,6 +222,8 @@ func (c *ConsulAlertClient) LoadConfig() {
 				valErr = loadCustomValue(&config.Notifiers.OpsGenie.ApiKey, val, ConfigTypeString)
 			case "consul-alerts/config/notifiers/opsgenie/api-url":
 				valErr = loadCustomValue(&config.Notifiers.OpsGenie.ApiUrl, val, ConfigTypeString)
+			case "consul-alerts/config/notifiers/opsgenie/details":
+				valErr = loadCustomValue(&config.Notifiers.OpsGenie.Details, val, ConfigTypeStrMap)
 
 				// AwsSns notifier config
 			case "consul-alerts/config/notifiers/awssns/cluster-name":

--- a/notifier/opsgenie-notifier.go
+++ b/notifier/opsgenie-notifier.go
@@ -15,6 +15,7 @@ type OpsGenieNotifier struct {
     ClusterName string `json:"cluster-name"`
     ApiKey      string `json:"api-key"`
     ApiUrl      string `json:"api-url"`
+    Details     map[string]string `json:"details"`
 }
 
 // NotifierName provides name for notifier selection
@@ -87,6 +88,7 @@ func (opsgenie *OpsGenieNotifier) createAlert(alertCli *ogcli.OpsGenieAlertV2Cli
         Alias:       alias,
         Source:      "consul",
         Entity:      opsgenie.ClusterName,
+        Details:     opsgenie.Details,
     }
     response, alertErr := alertCli.Create(req)
 


### PR DESCRIPTION
This MR adds the ability to add details (key value attributes)  to the created opsgenie alerts. 
This a good way to add information like environment to an alert. 